### PR TITLE
add installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,9 @@ A test being:
 
 * All the goodies from [zora](https://github.com/lorenzofox3/zora)
 
+## Installation
+`npm i --save-dev pta`
+
 ## Usage
 
 Write your spec files with a default export function taking as argument a zora's assertion object


### PR DESCRIPTION
- I tried installing `zora-node` first I thought that was the name of the package
- adding this would make it clear that it has a different name in `npm`
- I've added this just before **Usage**
- related #6