### PR TITLE
pathtoFileURL for Windows

### DIFF
--- a/src/loader.js
+++ b/src/loader.js
@@ -1,5 +1,6 @@
 import {createRequire} from 'module';
 import {resolve} from 'path';
+import {pathToFileURL} from 'url';
 
 export default async ({loader = 'ES', path}) => {
     if (loader === 'cjs') {
@@ -9,7 +10,7 @@ export default async ({loader = 'ES', path}) => {
     return loadES(path);
     
     async function loadES(path) {
-        const module = await import(resolve(process.cwd(), path));
+        const module = await import(pathToFileURL(resolve(process.cwd(), path)));
         return module.default;
     }
     


### PR DESCRIPTION
So, the testrunner as it stands when used in Windows environment with ES modules fails with the following error:
`Error [ERR_UNSUPPORTED_ESM_URL_SCHEME]: Only file and data URLs are supported by the default ESM loader. Absolute Windows paths without prefix are not valid URLs, consider using 'file://' prefix. Received protocol 'c:'`
And the default way to fix it is to use `pathToFileURL`.
Tested it on Linux as well, this fix seems to be working too.